### PR TITLE
Screen sessions are 1-to-1

### DIFF
--- a/webcontrol.client.js
+++ b/webcontrol.client.js
@@ -94,7 +94,7 @@ export class WebControlController extends WebControl {
     const socket = this.socket
     this.saveTabSessionId()
     socket.on('connect', () => {
-      socket.emit('alreadyLinked', parseInt(this.getSpecialNumber(), 10), socket.id)
+      socket.emit('alreadyLinked', parseInt(this.getSpecialNumber(), 10), socket.id, this.getTabSessionId())
     })
     socket.on('alreadyLinked', (value) => {
       value ? sessionStorage.setItem('widgetOn', true) : sessionStorage.setItem('widgetOn', false)
@@ -110,12 +110,12 @@ export class WebControlController extends WebControl {
   }
 
   linkController (numberValue) {
-    this.socket.emit('linkController', parseInt(numberValue, 10), this.socket.id)
-    this.alreadyLinked(numberValue)
+    this.socket.emit('linkController', parseInt(numberValue, 10), this.socket.id, this.getTabSessionId())
+    this.alreadyLinked(numberValue, this.getTabSessionId())
   }
 
-  alreadyLinked (numberValue) {
-    this.socket.emit('alreadyLinked', parseInt(numberValue, 10), this.socket.id)
+  alreadyLinked (numberValue, sessionId) {
+    this.socket.emit('alreadyLinked', parseInt(numberValue, 10), this.socket.id, sessionId)
   }
 
   send (value) {
@@ -137,13 +137,17 @@ export class WebControlController extends WebControl {
     })
   }
 
-  tabSessionId () {
+  createTabSessionId () {
     return Math.random().toString(36).substring(2)
+  }
+
+  getTabSessionId () {
+    return sessionStorage.getItem('tabSessionId')
   }
 
   saveTabSessionId () {
     if (!sessionStorage.getItem('tabSessionId')) {
-      sessionStorage.setItem('tabSessionId', this.tabSessionId())
+      sessionStorage.setItem('tabSessionId', this.createTabSessionId())
     }
   }
 }

--- a/webcontrol.client.js
+++ b/webcontrol.client.js
@@ -16,7 +16,7 @@ export default class WebControl {
           sessionStorage.setItem('widgetOn', true)
           return response
         } else {
-          sessionStorage.clear()
+          this.clearControllerStorage()
         }
       }
     }
@@ -131,7 +131,7 @@ export class WebControlController extends WebControl {
   // used as an empty function and therefore has no effect
   unpairController (func = () => {}) {
     this.socket.on('unpairController', () => {
-      sessionStorage.clear()
+      this.clearControllerStorage()
       sessionStorage.setItem('widgetOn', false)
       func()
     })
@@ -149,5 +149,10 @@ export class WebControlController extends WebControl {
     if (!sessionStorage.getItem('tabSessionId')) {
       sessionStorage.setItem('tabSessionId', this.createTabSessionId())
     }
+  }
+
+  clearControllerStorage () {
+    sessionStorage.removeItem('specialNumber')
+    sessionStorage.removeItem('widgetOn')
   }
 }

--- a/webcontrol.client.js
+++ b/webcontrol.client.js
@@ -92,6 +92,7 @@ export class WebControlController extends WebControl {
 
   controller () {
     const socket = this.socket
+    this.saveTabSessionId()
     socket.on('connect', () => {
       socket.emit('alreadyLinked', parseInt(this.getSpecialNumber(), 10), socket.id)
     })
@@ -134,5 +135,15 @@ export class WebControlController extends WebControl {
       sessionStorage.setItem('widgetOn', false)
       func()
     })
+  }
+
+  tabSessionId () {
+    return Math.random().toString(36).substring(2)
+  }
+
+  saveTabSessionId () {
+    if (!sessionStorage.getItem('tabSessionId')) {
+      sessionStorage.setItem('tabSessionId', this.tabSessionId())
+    }
   }
 }


### PR DESCRIPTION
- Each controller tab has a sessionId to avoid having multiple tabs with the same special number.
- The sessionId is sent to the server
- Controller storage data is cleared when the session expired/ is unpaired